### PR TITLE
Subsonic flag added

### DIFF
--- a/lua/arccw/shared/attachments/uc_powder_subsonic.lua
+++ b/lua/arccw/shared/attachments/uc_powder_subsonic.lua
@@ -28,3 +28,7 @@ att.Override_TracerNum = 0
 
 att.Mult_MalfunctionMean = 1.3
 att.Mult_PhysBulletMuzzleVelocity = 0.75
+
+att.GiveFlags = {
+    "subsonic"
+    }


### PR DESCRIPTION
To dissallow subsonic option for a calibre that is inherently subsonic add lines: 
att.ExcludeFlags = {
    "subsonic"
    }